### PR TITLE
Allow DMS_PING_URL to be empty.

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -16,7 +16,7 @@ DMS_API_KEY = config('DMS_API_KEY')
 NEW_RELIC_API_KEY = config('NEW_RELIC_API_KEY')
 NEW_RELIC_QUERY_KEY = config('NEW_RELIC_QUERY_KEY')
 
-DMS_PING_URL = config('DMS_PING_URL')
+DMS_PING_URL = config('DMS_PING_URL', default=None)
 
 SENTRY_DSN = config('SENTRY_DSN', default=None)
 


### PR DESCRIPTION
When developing we don't need to ping DMS.
