### PR TITLE
Add Redux data store in preparation for service detail view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .env*
 lambda-*.zip
+npm-debug.log
 venv
 status.yml

--- a/local-dev/package.json
+++ b/local-dev/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "devDependencies": {
     "fs-extra": "^0.30.0",
-    "gh-pages": "^0.11.0",
     "react-scripts": "0.1.0"
   },
   "dependencies": {
@@ -12,7 +11,12 @@
     "js-yaml": "^3.6.1",
     "react": "^15.2.1",
     "react-dom": "^15.2.1",
-    "react-router": "^2.6.0"
+    "react-redux": "^4.4.5",
+    "react-router": "^2.6.0",
+    "react-router-redux": "^4.0.5",
+    "redux": "^3.5.2",
+    "redux-logger": "^2.6.1",
+    "redux-thunk": "^2.1.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/local-dev/src/actions/actionCreators.js
+++ b/local-dev/src/actions/actionCreators.js
@@ -1,0 +1,108 @@
+/*
+Global functions ("actions") that can be invoked by components. These actions
+are consumed by reducers.
+*/
+
+import fetch from 'isomorphic-fetch';
+import jsyaml from 'js-yaml';
+
+export const REQUEST_GLOBAL_STATUS = 'REQUEST_GLOBAL_STATUS';
+// Dispatched from fetchGlobalStatus.
+// Nicety to inform app that request to status.yml is in progress.
+export function requestGlobalStatus() {
+    return {
+        type: REQUEST_GLOBAL_STATUS
+    }
+}
+
+export const RECEIVE_GLOBAL_STATUS = 'RECEIVE_GLOBAL_STATUS';
+// Dispatched from async function returned by fetchGlobalStatus.
+export function receiveGlobalStatus(newGlobalStatus) {
+    return {
+        type: RECEIVE_GLOBAL_STATUS,
+        data: newGlobalStatus
+    }
+}
+
+// Returns a function that performs async action, then dispatches another
+// action (requires thunk middleware).
+export function fetchGlobalStatus() {
+    return function(dispatch) {
+        // Inform app that we are looking for updates to status.yml.
+        dispatch(requestGlobalStatus());
+
+        // Make an AJAX request to status.yml.
+        return fetch('/status.yml?date=' + Date.now()).then(response => {
+            if (response.ok) {
+                response.text().then(text => {
+                    // Convert YAML formatted text to JS object.
+                    const statusData = jsyaml.load(text);
+
+                    // Build services array.
+                    const services = Object.keys(statusData.components).map(key => {
+                        return statusData.components[key];
+                    });
+
+                    // Build an object of new data to be sent to
+                    // receiveGlobalStatus.
+                    const newGlobalStatus = {
+                        status: statusData.globalStatus.status,
+                        message: statusData.globalStatus.message,
+                        services: services,
+                        lastUpdate: new Date()
+                    };
+
+                    // Dispatch receiveGlobalStatus action, passing in new data.
+                    dispatch(receiveGlobalStatus(newGlobalStatus));
+                });
+            } else {
+                console.error('status.yml response not ok :(');
+            }
+        }).catch((err) => {
+            console.error('fetch error!');
+            console.error(err);
+        });
+    }
+}
+
+export const RECEIVE_DESKTOP_NOTIFY = 'RECEIVE_DESKTOP_NOTIFY';
+// Receives a JS object from requestDesktopNotify action.
+export function receiveDesktopNotify(newDesktopNotify) {
+    return {
+        type: RECEIVE_DESKTOP_NOTIFY,
+        desktopNotify: newDesktopNotify
+    }
+}
+
+// Returns a function that performs async action, then dispatches another
+// action (requires thunk middleware).
+export function requestDesktopNotify() {
+    return function(dispatch) {
+        // If browser doesn't support notifications, we're done here.
+        if (!('Notification' in window)) {
+            dispatch(receiveDesktopNotify(false));
+        }
+        // Check whether notification permissions have already been granted.
+        else if (Notification.permission === 'granted') {
+            dispatch(receiveDesktopNotify(true));
+        }
+        // Otherwise, we need to ask the user for permission.
+        else if (Notification.permission !== 'denied') {
+            Notification.requestPermission(permission => {
+                if (permission === 'granted') {
+                    dispatch(receiveDesktopNotify(true));
+                } else {
+                    dispatch(receiveDesktopNotify(false));
+                }
+            });
+        }
+    }
+}
+
+export const CLEAR_DESKTOP_NOTIFY = 'CLEAR_DESKTOP_NOTIFY';
+// Dispatched after displaying desktop notification to avoid duplicate notices.
+export function clearDesktopNotify() {
+    return {
+        type: CLEAR_DESKTOP_NOTIFY
+    }
+}

--- a/local-dev/src/components/App.js
+++ b/local-dev/src/components/App.js
@@ -1,0 +1,28 @@
+/*
+Component that wraps any child component requiring our Redux data store.
+*/
+
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import * as actionCreators from '../actions/actionCreators';
+import Main from './Main';
+
+// Converts state to an object to be passed as props to Main component.
+function mapStateToProps(state) {
+    return {
+        global: state.global,
+        serviceDetail: state.serviceDetail
+    };
+}
+
+// Allows all action creators (from actions/actionCreators.js) to be called
+// directly (instead of through the 'dispatch' method).
+function mapDispatchToProps(dispatch) {
+    return bindActionCreators(actionCreators, dispatch);
+}
+
+// Adds state and action creators as props to Main component.
+// This is much more convenient than passing props down many levels.
+const App = connect(mapStateToProps, mapDispatchToProps)(Main);
+
+export default App;

--- a/local-dev/src/components/GlobalStatus.js
+++ b/local-dev/src/components/GlobalStatus.js
@@ -28,6 +28,7 @@ class GlobalStatus extends Component {
 
         return result;
     }
+
     statusToIcon(status) {
         var img;
 
@@ -45,10 +46,11 @@ class GlobalStatus extends Component {
             default:
                 break;
         }
+
         return img;
     }
+
     setFavicon(status) {
-        // update favicon
         var favicon = document.getElementById('favicon');
         var img = this.statusToIcon(status);
 
@@ -56,23 +58,28 @@ class GlobalStatus extends Component {
             favicon.href = img;
         }
     }
+
     sendDesktopNotification(message, icon) {
         var options = {
             body: 'Mozilla Engagement Engineering Status Board',
             icon: icon
         };
+
         new Notification(message, options);
+
+        // Make sure notification isn't duplicated if view changes before next
+        // global status request.
+        this.props.clearDesktopNotify();
     }
+
     render() {
         this.setFavicon(this.props.status);
 
-        if (this.props.desktopNotify &&
-            this.props.oldStatus && this.props.oldStatus !== 'pending' &&
-            this.props.status !== this.props.oldStatus) {
-                this.sendDesktopNotification(this.props.message, this.statusToIcon(this.props.status));
-        }
-
         var className = 'alert alert-' + this.statusToColor(this.props.status);
+
+        if (this.props.desktopNotify === true && this.props.notifyMessage === true) {
+            this.sendDesktopNotification(this.props.message, this.statusToIcon(this.props.status));
+        }
 
         return (
             <div className={className} role="alert">

--- a/local-dev/src/components/Header.js
+++ b/local-dev/src/components/Header.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router';
 
 import logo from '../img/logo.png';
 
@@ -6,9 +7,9 @@ class Header extends Component {
     render() {
         return (
             <h1 id="logo">
-                <a href="/">
+                <Link to="/">
                     <img src={logo} alt="Mozilla Engagement Engineering Status Board" />
-                </a>
+                </Link>
             </h1>
         )
     }

--- a/local-dev/src/components/Main.js
+++ b/local-dev/src/components/Main.js
@@ -1,0 +1,31 @@
+/*
+Serves as a proxy to pass Redux store info down to child components. Invoked by
+components/App.js.
+*/
+
+import React, { Component } from 'react';
+
+class Main extends Component {
+    // Actions that will happen for all child components.
+    componentDidMount() {
+        // Invoke action to get global status on page load.
+        this.props.fetchGlobalStatus();
+
+        // Poll global status every 60 seconds.
+        setInterval(this.props.fetchGlobalStatus, 60000);
+
+        // Invoke action to get desktop notify permission.
+        this.props.requestDesktopNotify();
+    }
+
+    render() {
+        return (
+            <div id="wrapper">
+                {/* passes props down to child element */}
+                {React.cloneElement(this.props.children, this.props)}
+            </div>
+        )
+    }
+};
+
+export default Main;

--- a/local-dev/src/components/ServiceDetail.js
+++ b/local-dev/src/components/ServiceDetail.js
@@ -1,17 +1,26 @@
+/*
+Displays details about a given service. (Coming soon...)
+*/
+
 import React, { Component } from 'react';
 
 import Header from './Header';
+import GlobalStatus from './GlobalStatus';
 
 class ServiceDetail extends Component {
-    constructor(props) {
-        super(props);
-    }
-
     render() {
         return (
             <div id="service-detail">
+                <GlobalStatus
+                    desktopNotify={this.props.global.desktopNotify}
+                    message={this.props.global.message}
+                    notifyMessage={this.props.global.notifyMessage}
+                    status={this.props.global.status}
+                    clearDesktopNotify={this.props.clearDesktopNotify}/>
                 <Header />
-                And then some service detail stuff down here...
+                <p>
+                    Details about the service...
+                </p>
             </div>
         );
     }

--- a/local-dev/src/components/StatusBoard.js
+++ b/local-dev/src/components/StatusBoard.js
@@ -1,7 +1,5 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
-import fetch from 'isomorphic-fetch';
-import jsyaml from 'js-yaml';
 
 import Header from './Header';
 import GlobalStatus from './GlobalStatus';
@@ -29,7 +27,7 @@ class Service extends Component {
         return (
             <li className="list-group-item">
                 {this.getBadge()}
-                {/* soon... <Link to={`/service/${this.props.id}`}>{this.props.name}</Link>*/}
+                {/* soon...seriously <Link to={`/service/${this.props.id}`}>{this.props.name}</Link> */}
                 {this.props.name}
                 &nbsp;
                 {this.getLink()}
@@ -137,8 +135,8 @@ class ServiceList extends Component {
     }
 
     /**
-     *  Group order is defined by the component in the group with the minimum
-     *  order value.
+     * Group order is defined by the component in the group with the minimum
+     * order value.
      *
      * Default is DEFAULT_ORDER_VALUE.
      */
@@ -193,88 +191,21 @@ class ServiceList extends Component {
 }
 
 class StatusBoard extends Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            globalStatusMessage: 'Fetching data.',
-            globalStatus: 'pending',
-            oldGlobalStatus: null,
-            services: [],
-            lastUpdate: null,
-            desktopNotify: false
-        };
-    }
-
-    updateStatus() {
-        fetch('./status.yml?date=' + Date.now()).then(response => {
-            if (response.ok) {
-                response.text().then(text => {
-                    this.updateStateFromYaml(text);
-                });
-            } else {
-                console.error('status.yml response not ok :(');
-            }
-        }).catch((err) => {
-            console.error('fetch error!');
-            console.error(err);
-        });
-    }
-
-    updateStateFromYaml(yaml) {
-        var statusData = jsyaml.load(yaml);
-        var services = Object.keys(statusData.components).map(key => {
-            return statusData.components[key];
-        });
-
-        this.setState({
-            oldGlobalStatus: this.state.globalStatus,
-            globalStatus: statusData.globalStatus.status,
-            globalStatusMessage: statusData.globalStatus.message,
-            services: services,
-            lastUpdate: new Date()
-        });
-    }
-
-    componentDidMount() {
-        this.updateStatus();
-        setInterval(this.updateStatus.bind(this), 60000);
-        this.getDesktopNotifyPermission();
-    }
-
-    getDesktopNotifyPermission(message, icon) {
-        if (!('Notification' in window)) {
-            return;
-        }
-        // Let's check whether notification permissions have already been granted
-        else if (Notification.permission === 'granted') {
-            this.setState({desktopNotify: true});
-        }
-        // Otherwise, we need to ask the user for permission
-        else if (Notification.permission !== 'denied') {
-            Notification.requestPermission(permission => {
-                // If the user accepts, let's create a notification
-                if (permission === 'granted') {
-                    this.setState({desktopNotify: true});
-                }
-            });
-        }
-    }
-
     render() {
         // update last updated timestamp
         var lastUpdate = document.getElementById('last-update');
-        lastUpdate.textContent = 'Last Update: ' + this.state.lastUpdate;
+        lastUpdate.textContent = 'Last Update: ' + this.props.global.lastUpdate;
 
         return (
             <div id="status-board">
                 <GlobalStatus
-                    message={this.state.globalStatusMessage}
-                    status={this.state.globalStatus}
-                    oldStatus={this.state.oldGlobalStatus}
-                    desktopNotify={this.state.desktopNotify} />
+                    desktopNotify={this.props.global.desktopNotify}
+                    message={this.props.global.message}
+                    notifyMessage={this.props.global.notifyMessage}
+                    status={this.props.global.status}
+                    clearDesktopNotify={this.props.clearDesktopNotify}/>
                 <Header />
-                <ServiceList services={this.state.services} />
+                <ServiceList services={this.props.global.services} />
             </div>
         );
     }

--- a/local-dev/src/index.js
+++ b/local-dev/src/index.js
@@ -1,6 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { Router, Route, browserHistory } from 'react-router';
+import { Router, Route, IndexRoute } from 'react-router';
+import { Provider } from 'react-redux';
+import store, { history } from './reduxStore';
+
+import App from './components/App';
 import StatusBoard from './components/StatusBoard';
 import ServiceDetail from './components/ServiceDetail';
 import './css/libs/bootstrap.3.3.6.min.css';
@@ -8,8 +12,12 @@ import './css/libs/bootstrap-theme.3.3.6.min.css';
 import './css/style.css'
 
 ReactDOM.render((
-    <Router history={browserHistory}>
-        <Route path="/" component={StatusBoard}/>
-        <Route path="/service/:serviceId" component={ServiceDetail}/>
-    </Router>
+    <Provider store={store}>
+        <Router history={history}>
+            <Route path="/" component={App}>
+                <IndexRoute component={StatusBoard}/>
+                <Route path="/service/:serviceId" component={ServiceDetail}/>
+            </Route>
+        </Router>
+    </Provider>
 ), document.getElementById('root'));

--- a/local-dev/src/reducers/global.js
+++ b/local-dev/src/reducers/global.js
@@ -1,0 +1,69 @@
+/*
+Reducers for actions related to globalStatus state data.
+*/
+
+import {
+    REQUEST_GLOBAL_STATUS,
+    RECEIVE_GLOBAL_STATUS,
+    RECEIVE_DESKTOP_NOTIFY,
+    CLEAR_DESKTOP_NOTIFY } from '../actions/actionCreators';
+
+// This reducer automatically gets a filtered 'state'.
+// It gets state.global only (not the full state stored by Redux).
+function global(globalState = {}, action) {
+    let newGlobalState;
+
+    // All reducers are fired for all actions, so check action type.
+    switch (action.type) {
+        case REQUEST_GLOBAL_STATUS:
+            // Take everything currently in state.global and put in in a new
+            // object. Then overwrite that with values provided last - namely
+            // changing 'isUpdating' to true.
+            newGlobalState = Object.assign({}, globalState, {
+                //notifyMessage: false, // prevent duplicating notifications
+                isUpdating: true
+            });
+
+            break;
+        case RECEIVE_GLOBAL_STATUS:
+            // Should we send a desktop notification?
+            let notifyMessage = false;
+
+            // If status has changed and old status wasn't 'pending', flag
+            // state to send a notification.
+            if (action.data.status !== globalState.status && globalState.status !== 'pending') {
+                notifyMessage = true;
+            }
+
+            newGlobalState = Object.assign({}, globalState, {
+                isUpdating: false,
+                message: action.data.message,
+                notifyMessage,
+                lastUpdate: action.data.lastUpdate,
+                services: action.data.services,
+                status: action.data.status
+            });
+
+            break;
+        case RECEIVE_DESKTOP_NOTIFY:
+            newGlobalState = Object.assign({}, globalState, {
+                desktopNotify: action.desktopNotify
+            });
+
+            break;
+        case CLEAR_DESKTOP_NOTIFY:
+            newGlobalState = Object.assign({}, globalState, {
+                notifyMessage: false
+            });
+
+            break;
+        default:
+            // If unknown action.type comes in, ignore and keep current state.
+            newGlobalState = globalState;
+            break;
+    }
+
+    return newGlobalState;
+}
+
+export default global;

--- a/local-dev/src/reducers/index.js
+++ b/local-dev/src/reducers/index.js
@@ -1,0 +1,10 @@
+import { combineReducers } from 'redux';
+import { routerReducer } from 'react-router-redux';
+
+// One reducer for each piece of state
+import global from './global';
+import serviceDetail from './serviceDetail';
+
+const rootReducer = combineReducers({ global, serviceDetail, routing: routerReducer });
+
+export default rootReducer;

--- a/local-dev/src/reducers/serviceDetail.js
+++ b/local-dev/src/reducers/serviceDetail.js
@@ -1,0 +1,14 @@
+/*
+Reducers for actions related to serviceDetail state data.
+*/
+
+function serviceDetail(state = [], action) {
+    if (action.type === 'UPDATE_SERVICE_DETAIL') {
+        console.log('gonna poll detail for the current service!');
+        return state;
+    } else {
+        return state;
+    }
+}
+
+export default serviceDetail;

--- a/local-dev/src/reduxStore.js
+++ b/local-dev/src/reduxStore.js
@@ -1,0 +1,46 @@
+import { browserHistory } from 'react-router';
+// allows sync between react-router and redux store
+import { syncHistoryWithStore } from 'react-router-redux';
+
+import { applyMiddleware, createStore } from 'redux';
+import createLogger from 'redux-logger';
+// for async reducers
+import thunkMiddleware from 'redux-thunk';
+
+import rootReducer from './reducers/index';
+
+const loggerMiddleware = createLogger();
+
+const defaultState = {
+    global: {
+        desktopNotify: false,
+        isUpdating: false,
+        lastUpdate: null,
+        message: 'Fetching data...',
+        notifyMessage: false,
+        services: [],
+        status: 'pending'
+    },
+    serviceDetail: {}
+}
+
+const store = createStore(
+    rootReducer,
+    defaultState,
+    applyMiddleware(
+        thunkMiddleware,
+        loggerMiddleware)
+);
+
+export const history = syncHistoryWithStore(browserHistory, store);
+
+// hot reload reducers
+if (module.hot) {
+    module.hot.accept('./reducers/', () => {
+        // cannot import inside a function - must use 'require' instead
+        const nextRootReducer = require('./reducers/index').default;
+        store.replaceReducer(nextRootReducer);
+    });
+}
+
+export default store;


### PR DESCRIPTION
This is a pretty sizable change, both in code and architecture. It'll really pay off as soon as we build out the `ServiceDetail.js` component.

To test Redux on the Service Detail view, uncomment line 30 in `StatusBoard.js` (and comment out line 31). This will let you change views while using the same Redux data store.
